### PR TITLE
Support crystal 0.36 && 1.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,6 @@
 name: seg
 version: 0.1.0
+crystal: ">= 0.36.0 - 1.0"
 
 authors:
   - Michel Martens <mail@soveran.com>
@@ -10,5 +11,3 @@ development_dependencies:
   crotest:
     github: emancu/crotest
     version: ~> 1.0.1
-
-crystal: "0.36.1, ~> 1.0.0"


### PR DESCRIPTION
Hi @soveran,

I've given you a bad advice on https://github.com/the-benchmarker/web-frameworks/pull/4098#issuecomment-813210539.

This is working way to allow compilation on both 0.36 (needed for https://github.com/the-benchmarker/web-frameworks) and 1.0 (needed for https://github.com/the-benchmarker/web-frameworks/pull/4098).

Regards,

PS : After this one is merged, I can open the same PR for `toro`